### PR TITLE
demo编译时，css样式不正确

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "wepy-compiler-babel": "^1.5.1",
     "wepy-compiler-less": "^1.3.10",
-    "wepy-compiler-sass": "0.0.3",
+    "wepy-compiler-sass": "^1.3.12",
     "wepy-eslint": "^1.5.3",
     "wepy-plugin-imagemin": "^1.5.2",
     "wepy-plugin-uglifyjs": "^1.3.6"


### PR DESCRIPTION
wepy-compiler-sass 版本过低，导致sass文件本能正确编译，程序运行时样式全无。